### PR TITLE
Dev/0.4.3

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "joycon-rs"
-version = "0.4.2"
+version = "0.4.3"
 authors = ["Kaisei Yokoyama <yokoyama.kaisei.sm@alumni.tsukuba.ac.jp>"]
 repository = "https://github.com/KaiseiYokoyama/joycon-rs"
 edition = "2018"

--- a/src/joycon/driver.rs
+++ b/src/joycon/driver.rs
@@ -434,7 +434,11 @@ pub trait JoyConDriver {
     fn set_rumble_status(&mut self, rumble_l_r: (Option<Rumble>, Option<Rumble>));
 
     /// Set rumble status and send rumble command to JoyCon.
+    /// If Joy-Con's rumble feature isn't activated, activate it.
     fn rumble(&mut self, rumble_l_r: (Option<Rumble>, Option<Rumble>)) -> JoyConResult<usize> {
+        if !self.enabled_features().contains(&JoyConFeature::Vibration) {
+            self.enable_feature(JoyConFeature::Vibration);
+        }
         self.set_rumble_status(rumble_l_r);
         self.send_command_raw(Command::Rumble as u8, 0, &[])
     }


### PR DESCRIPTION
# CHANGELOG
## Changed
- `JoyConDriver::rumble`'s default implementation enables rumble feature of Joy-Con automatically.