### PR TITLE
Dev/0.4.4

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "joycon-rs"
-version = "0.4.3"
+version = "0.4.4"
 authors = ["Kaisei Yokoyama <yokoyama.kaisei.sm@alumni.tsukuba.ac.jp>"]
 repository = "https://github.com/KaiseiYokoyama/joycon-rs"
 edition = "2018"

--- a/examples/rumble.rs
+++ b/examples/rumble.rs
@@ -33,12 +33,13 @@ fn main() -> JoyConResult<()> {
 
             driver.enable_feature(JoyConFeature::Vibration)?;
 
-            // let rumble = Rumble::new(80.0,0.2);
             let rumble = Rumble::new(300.0,0.9);
             driver.rumble((Some(rumble), Some(rumble)))?;
 
             std::thread::sleep(std::time::Duration::from_millis(60));
-            driver.rumble((None,None))?;
+
+            let stop = Rumble::stop();
+            driver.rumble((Some(stop),Some(stop)))?;
 
             Ok(())
         })?;

--- a/examples/rumble.rs
+++ b/examples/rumble.rs
@@ -37,6 +37,9 @@ fn main() -> JoyConResult<()> {
             let rumble = Rumble::new(300.0,0.9);
             driver.rumble((Some(rumble), Some(rumble)))?;
 
+            std::thread::sleep(std::time::Duration::from_millis(60));
+            driver.rumble((None,None))?;
+
             Ok(())
         })?;
 

--- a/src/joycon/driver.rs
+++ b/src/joycon/driver.rs
@@ -458,13 +458,11 @@ pub trait JoyConDriver {
 
         // rumble
         let (rumble_l, rumble_r) = self.get_rumble_status();
-        {
-            let rumble_l = rumble_l.unwrap_or(Rumble::new(40.0, 0.0));
+        if let Some(rumble_l) = rumble_l {
             let rumble_left: [u8; 4] = rumble_l.into();
             buf[2..6].copy_from_slice(&rumble_left);
         }
-        {
-            let rumble_r = rumble_r.unwrap_or(Rumble::new(40.0, 0.0));
+        if let Some(rumble_r) = rumble_r {
             let rumble_right: [u8; 4] = rumble_r.into();
             buf[6..10].copy_from_slice(&rumble_right);
         }


### PR DESCRIPTION
# CHANGELOG
## Fix
- `Into<[u8;4]> for Rumble` has been fixed. 
   - With this change, `Rumble::stop()`'s value stops rumbling of Joy-Con now.