### PR TITLE
Dev/0.5.2

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -16,6 +16,7 @@ exclude = ["/images/*"]
 [dependencies]
 hidapi-alt-for-hidapi-issue-127 = "1.2.1"
 crossbeam-channel = "0.4.2"
+lazy_static = "1.4.0"
 
 [dev-dependencies]
 doc-comment = "0.3.3"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "joycon-rs"
-version = "0.5.1"
+version = "0.5.2"
 authors = ["Kaisei Yokoyama <yokoyama.kaisei.sm@alumni.tsukuba.ac.jp>"]
 repository = "https://github.com/KaiseiYokoyama/joycon-rs"
 edition = "2018"

--- a/src/joycon/manager.rs
+++ b/src/joycon/manager.rs
@@ -291,3 +291,13 @@ impl JoyConManager {
     }
 }
 
+lazy_static! {
+    pub static ref JOYCON_RECEIVER: crossbeam_channel::Receiver<Arc<Mutex<JoyConDevice>>> = {
+        let manager = JoyConManager::get_instance();
+        let manager = match manager.lock() {
+            Ok(manager) => manager,
+            Err(e) => e.into_inner(),
+        };
+        manager.new_devices()
+    };
+}

--- a/src/joycon/manager.rs
+++ b/src/joycon/manager.rs
@@ -82,26 +82,30 @@ impl JoyConManager {
 
             std::thread::spawn(move || {
                 while let Some(manager) = manager.upgrade() {
-                    // Get manager
-                    let mut manager = match manager.lock() {
-                        Ok(m) => m,
-                        Err(m) => m.into_inner(),
+                    let interval = {
+                        // Get manager
+                        let mut manager = match manager.lock() {
+                            Ok(m) => m,
+                            Err(m) => m.into_inner(),
+                        };
+
+                        // Send new devices
+                        if let Ok(new_devices) = manager.scan() {
+                            // If mpsc channel is disconnected, end this thread.
+                            let send_result = new_devices.into_iter()
+                                .try_for_each::<_, Result<(), crossbeam_channel::SendError<_>>>(|new_device| {
+                                    tx.send(new_device)
+                                });
+                            if send_result.is_err() {
+                                return;
+                            }
+                        }
+
+                        manager.scan_interval.clone()
                     };
 
-                    // Send new devices
-                    if let Ok(new_devices) = manager.scan() {
-                        // If mpsc channel is disconnected, end this thread.
-                        let send_result = new_devices.into_iter()
-                            .try_for_each::<_, Result<(), crossbeam_channel::SendError<_>>>(|new_device| {
-                                tx.send(new_device)
-                            });
-                        if send_result.is_err() {
-                            return;
-                        }
-                    }
-
                     // Sleep
-                    std::thread::sleep(manager.scan_interval)
+                    std::thread::sleep(interval)
                 }
             })
         };

--- a/src/joycon/mod.rs
+++ b/src/joycon/mod.rs
@@ -15,7 +15,7 @@ pub use driver::{
     lights,
     device_info,
 };
-pub use manager::JoyConManager;
+pub use manager::{JoyConManager, JOYCON_RECEIVER};
 
 use std::sync::Arc;
 use std::fmt::{Debug, Formatter};

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -145,6 +145,8 @@
 //! [Deal with LED (Player lights)]: joycon/lights/index.html
 //! [Vibration (Rumble)]:joycon/struct.Rumble.html
 extern crate hidapi_alt_for_hidapi_issue_127 as hidapi;
+#[macro_use]
+extern crate lazy_static;
 
 pub mod joycon;
 


### PR DESCRIPTION
## CHANGELOG
- Add `JOYCON_RECEIVER`
   - In any situations, `Arc<Mutex<JoyConManager>>::lock()` fails on Windows. If you want new devices, `JOYCON_RECEIVER: crossbeam_channel::Receiver<Arc<Mutex<JoyConDevice>>>` will provide them. 