### PR TITLE
Reduce failure chance with reconnecting joycons.

### DIFF
--- a/examples/standard_full_report.rs
+++ b/examples/standard_full_report.rs
@@ -1,5 +1,7 @@
 #![allow(unused_must_use)]
 
+use std::{thread, time::Duration};
+
 use joycon_rs::prelude::*;
 
 fn main() -> JoyConResult<()> {
@@ -26,12 +28,38 @@ fn main() -> JoyConResult<()> {
     };
 
     devices.iter().try_for_each::<_, JoyConResult<()>>(|d| {
-        let driver = SimpleJoyConDriver::new(&d)?;
-        let standard_full_mode = StandardFullMode::new(driver)?;
         let tx = tx.clone();
 
-        std::thread::spawn(move || loop {
-            tx.send(standard_full_mode.read_input_report()).unwrap();
+        std::thread::spawn(move || {
+            loop {
+                // Lock joycon and check if it is connected
+                if match d.lock() {
+                    Ok(d) => d,
+                    Err(d) => d.into_inner(),
+                }
+                .is_connected()
+                {
+                    // Lock is now dropped
+                    // Create driver and listen to standard reports
+                    if let Ok(driver) = SimpleJoyConDriver::new(&d) {
+                        if let Ok(standard_full_mode) = StandardFullMode::new(driver) {
+                            // Report loop
+                            loop {
+                                match standard_full_mode.read_input_report() {
+                                    Ok(report) => tx.send(report).unwrap(),
+                                    Err(JoyConError::Disconnected) => {
+                                        // Break out of report loop when device is disconnected
+                                        break;
+                                    }
+                                    Err(_) => {} // Ignore other errors
+                                };
+                            }
+                        }
+                    }
+                }
+                // Joycon was disconnected, check for reconnection after 1 second
+                thread::sleep(Duration::from_millis(1000));
+            }
         });
 
         Ok(())


### PR DESCRIPTION
I've been having some troubles with reconnecting joycons (as seen in #66 ), so I decided to try to rewrite the scanning code to fix this.

I don't fully think this is the best solution to the problem of reconnecting, but it is a solution that does work. And you can decide if it is appropriate for this project or not. A different solution could be that joycons that are reconnected are instead treated as a new joycon, but this would change the current api, and also need changed examples. 

I have only updated the `standard_full_report.rs` example to support reconnecting. Running `StandardFullMode::new(driver) ` must be done after each connect/reconnect, as otherwise the joycon doesn't send the correct data. The other examples also need to be updated if you decide to merge this.

- Reduce failure chance with reconnecting joycons.
- Simplify + refactor manager.rs scan.
- Reduce creation of unnecessary Joycon objects.
- Rewrite standard_full_report example to also support reconnecting joycons.